### PR TITLE
Make TestEz a normal dependency

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chipioindustries/random-selection"
 description = "A module for selecting a random item from a weighted list."
-version = "1.0.1"
+version = "1.0.2"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 exclude = ["wally.exe", "aftman", "*.zip"]
@@ -9,6 +9,4 @@ exclude = ["wally.exe", "aftman", "*.zip"]
 [dependencies]
 t = "osyrisrblx/t@3.0.0"
 Llama = "chipioindustries/llama@1.2.4"
-
-[dev-dependencies]
 TestEZ = "roblox/testez@0.4.1"


### PR DESCRIPTION
Workaround for Wally bug. Depending on TestEz as a dev-dependency prevents the package from being installed externally.